### PR TITLE
fix: use nixpkgs-stable for nushell package

### DIFF
--- a/home/nushell/default.nix
+++ b/home/nushell/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs-stable, ... }:
 {
   programs.nushell = {
     enable = true;
@@ -11,5 +11,8 @@
       e = "eza";
       el = "eza -l";
     };
+
+    # This is a workaround for the conflict with direnv's hook.
+    package = pkgs-stable.nushell;
   };
 }


### PR DESCRIPTION
This is a workaround for the conflict with direnv's hook.